### PR TITLE
Implement final video upload and shorts feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@
    ./gradlew bootRun
    ```
 
+## 데이터베이스 설정
+MySQL 8.0 컨테이너를 사용한다면 다음과 같이 실행할 수 있습니다.
+```bash
+docker run --name innerview-mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=innerview -d mysql:8.0
+```
+이후 `docs/mysql-schema.sql` 스크립트를 적용하여 테이블을 생성합니다.
+```bash
+docker exec -i innerview-mysql mysql -uroot -ppass innerview < docs/mysql-schema.sql
+```
+
 ## 주요 환경 변수
 모든 변수는 `.env.example` 파일을 참고하세요. 주요 변수는 다음과 같습니다.
 - `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET`, `KAKAO_REDIRECT_URI`

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,3 +13,21 @@
 - `POST /api/projects` (multipart/form-data)
 - `GET /api/projects`
 - `GET /api/projects/{id}`
+- `POST /api/projects/{id}/final` 업로드된 프로젝트의 완성 비디오 업로드
+- `GET /api/projects/{projectId}/final/original?contentId=` 완성 비디오 원본 다운로드
+- `GET /api/projects/{projectId}/final/hls/{contentId}/{file}` HLS 스트리밍 파일 제공
+- `GET /api/projects/{projectId}/final/status/{contentId}` HLS 처리 상태 조회
+
+## 비디오 상호작용
+- `POST /api/videos/{id}/views` 조회수 기록
+- `POST /api/videos/{id}/likes` 좋아요 등록
+- `POST /api/videos/{id}/comments` 댓글 작성
+- `GET /api/videos/{id}/comments` 댓글 목록 조회
+
+## 사용자 정보
+- `GET /api/me` 내 정보 조회
+- `PUT /api/me` 내 정보 수정
+- `GET /api/my/videos` 내가 업로드한 비디오 목록 조회
+
+## 쇼츠 피드
+- `GET /api/shorts` : 연속 재생을 위한 다음 비디오 목록 조회

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -33,3 +33,36 @@
   - video_file_name
   - edit_data
   - created_at
+
+- **video_contents**: 편집을 마친 비디오와 HLS 정보
+  - id (PK)
+  - project_id (FK: video_projects.id)
+  - original_file_name
+  - hls_path
+  - created_at
+
+- **video_processes**: HLS 변환 처리 상태
+  - id (PK)
+  - content_id (FK: video_contents.id)
+  - status
+  - message
+  - updated_at
+
+- **video_views**: 비디오 조회 기록
+  - id (PK)
+  - content_id (FK: video_contents.id)
+  - user_id (FK: users.id)
+  - created_at
+
+- **video_likes**: 비디오 좋아요
+  - id (PK)
+  - content_id (FK: video_contents.id)
+  - user_id (FK: users.id)
+  - created_at
+
+- **video_comments**: 비디오 댓글
+  - id (PK)
+  - content_id (FK: video_contents.id)
+  - user_id (FK: users.id)
+  - text
+  - created_at

--- a/docs/mysql-schema.sql
+++ b/docs/mysql-schema.sql
@@ -1,0 +1,86 @@
+CREATE TABLE users (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    username VARCHAR(255),
+    profile_image VARCHAR(255),
+    password VARCHAR(255),
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE oauth_users (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    provider VARCHAR(50) NOT NULL,
+    provider_id VARCHAR(100) NOT NULL,
+    access_token TEXT,
+    refresh_token TEXT,
+    expires_at DATETIME,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    UNIQUE KEY unique_provider_user (provider, provider_id),
+    CONSTRAINT fk_oauth_user_user FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE inner_views (
+    id CHAR(36) PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    type VARCHAR(20) NOT NULL,
+    created_at DATETIME NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE video_projects (
+    id CHAR(36) PRIMARY KEY,
+    user_id BIGINT,
+    project_name VARCHAR(255) NOT NULL,
+    video_file_name VARCHAR(255) NOT NULL,
+    edit_data TEXT,
+    created_at DATETIME NOT NULL,
+    CONSTRAINT fk_video_project_user FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE video_contents (
+    id CHAR(36) PRIMARY KEY,
+    project_id CHAR(36) NOT NULL,
+    original_file_name VARCHAR(255) NOT NULL,
+    hls_path VARCHAR(255) NOT NULL,
+    created_at DATETIME,
+    CONSTRAINT fk_video_content_project FOREIGN KEY (project_id) REFERENCES video_projects(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE video_processes (
+    id CHAR(36) PRIMARY KEY,
+    content_id CHAR(36) NOT NULL,
+    status VARCHAR(20),
+    message TEXT,
+    updated_at DATETIME,
+    CONSTRAINT fk_video_process_content FOREIGN KEY (content_id) REFERENCES video_contents(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE video_views (
+    id CHAR(36) PRIMARY KEY,
+    content_id CHAR(36) NOT NULL,
+    user_id BIGINT,
+    created_at DATETIME,
+    CONSTRAINT fk_video_view_content FOREIGN KEY (content_id) REFERENCES video_contents(id),
+    CONSTRAINT fk_video_view_user FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE video_likes (
+    id CHAR(36) PRIMARY KEY,
+    content_id CHAR(36) NOT NULL,
+    user_id BIGINT NOT NULL,
+    created_at DATETIME,
+    CONSTRAINT fk_video_like_content FOREIGN KEY (content_id) REFERENCES video_contents(id),
+    CONSTRAINT fk_video_like_user FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE video_comments (
+    id CHAR(36) PRIMARY KEY,
+    content_id CHAR(36) NOT NULL,
+    user_id BIGINT NOT NULL,
+    text TEXT,
+    created_at DATETIME,
+    CONSTRAINT fk_video_comment_content FOREIGN KEY (content_id) REFERENCES video_contents(id),
+    CONSTRAINT fk_video_comment_user FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/java/com/dev/innverview/InnverviewApplication.java
+++ b/src/main/java/com/dev/innverview/InnverviewApplication.java
@@ -2,8 +2,10 @@ package com.dev.innverview;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class InnverviewApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/dev/innverview/controller/PageController.java
+++ b/src/main/java/com/dev/innverview/controller/PageController.java
@@ -1,0 +1,18 @@
+package com.dev.innverview.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class PageController {
+
+    @GetMapping("/signup")
+    public String signup() {
+        return "signup";
+    }
+
+    @GetMapping("/videos")
+    public String videos() {
+        return "videos";
+    }
+}

--- a/src/main/java/com/dev/innverview/controller/ProfileController.java
+++ b/src/main/java/com/dev/innverview/controller/ProfileController.java
@@ -1,0 +1,47 @@
+package com.dev.innverview.controller;
+
+import com.dev.innverview.domain.User;
+import com.dev.innverview.service.UserService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<User> me(@AuthenticationPrincipal UserDetails user) {
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+        return ResponseEntity.ok(userService.getByEmail(user.getUsername()));
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<User> update(@AuthenticationPrincipal UserDetails user,
+                                       @RequestBody UpdateReq req) {
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+        return ResponseEntity.ok(userService.update(user.getUsername(), req.getUsername(), req.getProfileImage()));
+    }
+
+    @GetMapping("/my/videos")
+    public ResponseEntity<?> myVideos(@AuthenticationPrincipal UserDetails user) {
+        if (user == null) return ResponseEntity.status(401).build();
+        return ResponseEntity.ok(userService.myVideos(user.getUsername()));
+    }
+
+    @Data
+    public static class UpdateReq {
+        private String username;
+        private String profileImage;
+    }
+}

--- a/src/main/java/com/dev/innverview/controller/VideoContentController.java
+++ b/src/main/java/com/dev/innverview/controller/VideoContentController.java
@@ -1,0 +1,63 @@
+package com.dev.innverview.controller;
+
+import com.dev.innverview.domain.VideoContent;
+import com.dev.innverview.service.VideoContentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class VideoContentController {
+
+    private final VideoContentService service;
+
+    @PostMapping("/projects/{id}/final")
+    public ResponseEntity<VideoContent> uploadFinal(@PathVariable UUID id,
+                                                    @RequestPart MultipartFile video) throws IOException {
+        VideoContent content = service.uploadFinalVideo(id, video);
+        return ResponseEntity.ok(content);
+    }
+
+    @GetMapping("/projects/{projectId}/final/original")
+    public ResponseEntity<FileSystemResource> downloadOriginal(@PathVariable UUID projectId,
+                                                               @RequestParam UUID contentId) {
+        VideoContent content = service.findById(contentId);
+        Path path = service.getOriginalPath(content);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(new FileSystemResource(path));
+    }
+
+    @GetMapping("/projects/{projectId}/final/hls/{contentId}/{file}")
+    public ResponseEntity<FileSystemResource> stream(@PathVariable UUID projectId,
+                                                     @PathVariable UUID contentId,
+                                                     @PathVariable String file) {
+        VideoContent content = service.findById(contentId);
+        Path path = service.getHlsPath(content).resolve(file);
+        return ResponseEntity.ok()
+                .contentType(file.endsWith(".m3u8") ? MediaType.APPLICATION_OCTET_STREAM : MediaType.APPLICATION_OCTET_STREAM)
+                .body(new FileSystemResource(path));
+    }
+
+    @GetMapping("/projects/{projectId}/final/status/{contentId}")
+    public ResponseEntity<?> status(@PathVariable UUID projectId, @PathVariable UUID contentId) {
+        VideoContent content = service.findById(contentId);
+        return ResponseEntity.ok(service.status(content));
+    }
+
+    @GetMapping("/shorts")
+    public List<VideoContent> shorts(@RequestParam(required = false) UUID after,
+                                     @RequestParam(defaultValue = "5") int size) {
+        return service.nextContents(after, size);
+    }
+}

--- a/src/main/java/com/dev/innverview/controller/VideoInteractionController.java
+++ b/src/main/java/com/dev/innverview/controller/VideoInteractionController.java
@@ -1,0 +1,57 @@
+package com.dev.innverview.controller;
+
+import com.dev.innverview.domain.VideoComment;
+import com.dev.innverview.service.VideoInteractionService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/videos")
+@RequiredArgsConstructor
+public class VideoInteractionController {
+
+    private final VideoInteractionService service;
+
+    @PostMapping("/{id}/views")
+    public ResponseEntity<?> view(@PathVariable UUID id,
+                                  @AuthenticationPrincipal UserDetails user) {
+        service.addView(id, user != null ? user.getUsername() : null);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/likes")
+    public ResponseEntity<?> like(@PathVariable UUID id,
+                                  @AuthenticationPrincipal UserDetails user) {
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+        service.like(id, user.getUsername());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/comments")
+    public ResponseEntity<VideoComment> comment(@PathVariable UUID id,
+                                                @AuthenticationPrincipal UserDetails user,
+                                                @RequestBody CommentReq req) {
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+        VideoComment comment = service.comment(id, user.getUsername(), req.getText());
+        return ResponseEntity.ok(comment);
+    }
+
+    @GetMapping("/{id}/comments")
+    public List<VideoComment> comments(@PathVariable UUID id) {
+        return service.comments(id);
+    }
+
+    @Data
+    public static class CommentReq { private String text; }
+}

--- a/src/main/java/com/dev/innverview/controller/VideoProjectController.java
+++ b/src/main/java/com/dev/innverview/controller/VideoProjectController.java
@@ -2,6 +2,7 @@ package com.dev.innverview.controller;
 
 import com.dev.innverview.domain.VideoProject;
 import com.dev.innverview.service.VideoProjectService;
+import com.dev.innverview.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,19 +20,22 @@ import java.util.UUID;
 public class VideoProjectController {
 
     private final VideoProjectService service;
+    private final UserService userService;
 
     @PostMapping
     public ResponseEntity<VideoProject> upload(@AuthenticationPrincipal UserDetails user,
                                                @RequestParam String projectName,
                                                @RequestParam String editData,
                                                @RequestPart MultipartFile video) throws IOException {
-        VideoProject saved = service.saveProject(null, projectName, editData, video);
+        VideoProject saved = service.saveProject(
+                user != null ? userService.getByEmail(user.getUsername()) : null,
+                projectName, editData, video);
         return ResponseEntity.ok(saved);
     }
 
     @GetMapping
     public List<VideoProject> list(@AuthenticationPrincipal UserDetails user) {
-        return service.list(null);
+        return service.list(user != null ? userService.getByEmail(user.getUsername()) : null);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/dev/innverview/domain/VideoComment.java
+++ b/src/main/java/com/dev/innverview/domain/VideoComment.java
@@ -1,0 +1,39 @@
+package com.dev.innverview.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "video_comments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private VideoContent content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(columnDefinition = "TEXT")
+    private String text;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dev/innverview/domain/VideoCommentRepository.java
+++ b/src/main/java/com/dev/innverview/domain/VideoCommentRepository.java
@@ -1,0 +1,10 @@
+package com.dev.innverview.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface VideoCommentRepository extends JpaRepository<VideoComment, UUID> {
+    List<VideoComment> findByContent(VideoContent content);
+}

--- a/src/main/java/com/dev/innverview/domain/VideoContent.java
+++ b/src/main/java/com/dev/innverview/domain/VideoContent.java
@@ -1,0 +1,38 @@
+package com.dev.innverview.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "video_contents")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoContent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private VideoProject project;
+
+    @Column(nullable = false)
+    private String originalFileName;
+
+    @Column(nullable = false)
+    private String hlsPath;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dev/innverview/domain/VideoContentRepository.java
+++ b/src/main/java/com/dev/innverview/domain/VideoContentRepository.java
@@ -1,0 +1,13 @@
+package com.dev.innverview.domain;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface VideoContentRepository extends JpaRepository<VideoContent, UUID> {
+    List<VideoContent> findByCreatedAtAfterOrderByCreatedAtAsc(LocalDateTime after, Pageable pageable);
+    List<VideoContent> findAllByOrderByCreatedAtAsc(Pageable pageable);
+}

--- a/src/main/java/com/dev/innverview/domain/VideoLike.java
+++ b/src/main/java/com/dev/innverview/domain/VideoLike.java
@@ -1,0 +1,36 @@
+package com.dev.innverview.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "video_likes")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private VideoContent content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dev/innverview/domain/VideoLikeRepository.java
+++ b/src/main/java/com/dev/innverview/domain/VideoLikeRepository.java
@@ -1,0 +1,10 @@
+package com.dev.innverview.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface VideoLikeRepository extends JpaRepository<VideoLike, UUID> {
+    long countByContent(VideoContent content);
+    boolean existsByContentAndUser(VideoContent content, User user);
+}

--- a/src/main/java/com/dev/innverview/domain/VideoProcess.java
+++ b/src/main/java/com/dev/innverview/domain/VideoProcess.java
@@ -1,0 +1,49 @@
+package com.dev.innverview.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "video_processes")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoProcess {
+
+    public enum Status {
+        PENDING,
+        PROCESSING,
+        COMPLETED,
+        FAILED
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private VideoContent content;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private String message;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dev/innverview/domain/VideoProcessRepository.java
+++ b/src/main/java/com/dev/innverview/domain/VideoProcessRepository.java
@@ -1,0 +1,9 @@
+package com.dev.innverview.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface VideoProcessRepository extends JpaRepository<VideoProcess, UUID> {
+    VideoProcess findByContent(VideoContent content);
+}

--- a/src/main/java/com/dev/innverview/domain/VideoProjectRepository.java
+++ b/src/main/java/com/dev/innverview/domain/VideoProjectRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface VideoProjectRepository extends JpaRepository<VideoProject, UUID> {
+    java.util.List<VideoProject> findByUser(User user);
 }

--- a/src/main/java/com/dev/innverview/domain/VideoView.java
+++ b/src/main/java/com/dev/innverview/domain/VideoView.java
@@ -1,0 +1,36 @@
+package com.dev.innverview.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "video_views")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoView {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private VideoContent content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = true)
+    private User user;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dev/innverview/domain/VideoViewRepository.java
+++ b/src/main/java/com/dev/innverview/domain/VideoViewRepository.java
@@ -1,0 +1,9 @@
+package com.dev.innverview.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface VideoViewRepository extends JpaRepository<VideoView, UUID> {
+    long countByContent(VideoContent content);
+}

--- a/src/main/java/com/dev/innverview/security/SecurityConfig.java
+++ b/src/main/java/com/dev/innverview/security/SecurityConfig.java
@@ -63,9 +63,10 @@ public class SecurityConfig {
 
                 // 권한 설정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/login", "/auth/**", "/oauth2/**", "/error").permitAll() // 공용 경로
-                        .requestMatchers("/admin/**").hasRole("ADMIN") // 관리자 전용 경로
-                        .anyRequest().authenticated() // 나머지 요청은 인증 필요
+                        .requestMatchers("/", "/login", "/signup", "/videos", "/auth/**", "/oauth2/**", "/error").permitAll()
+                        .requestMatchers("/api/shorts", "/api/projects/*/final/**").permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
                 )
                 .formLogin(form -> form
                         .loginPage("/login").permitAll()

--- a/src/main/java/com/dev/innverview/service/UserService.java
+++ b/src/main/java/com/dev/innverview/service/UserService.java
@@ -1,7 +1,7 @@
 package com.dev.innverview.service;
 
-import com.dev.innverview.domain.User;
-import com.dev.innverview.domain.UserRepository;
+import com.dev.innverview.domain.*;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -15,6 +15,8 @@ public class UserService implements UserDetailsService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final VideoContentRepository contentRepository;
+    private final VideoProjectRepository projectRepository;
 
     public User register(String email, String password) {
         if (userRepository.findByEmail(email).isPresent()) {
@@ -25,6 +27,25 @@ public class UserService implements UserDetailsService {
                 .password(passwordEncoder.encode(password))
                 .build();
         return userRepository.save(user);
+    }
+
+    public User getByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow();
+    }
+
+    public User update(String email, String username, String profileImage) {
+        User user = getByEmail(email);
+        user.setUsername(username);
+        user.setProfileImage(profileImage);
+        return userRepository.save(user);
+    }
+
+    public List<VideoContent> myVideos(String email) {
+        User user = getByEmail(email);
+        List<VideoProject> projects = projectRepository.findByUser(user);
+        return contentRepository.findAll().stream()
+                .filter(c -> projects.contains(c.getProject()))
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/dev/innverview/service/VideoContentService.java
+++ b/src/main/java/com/dev/innverview/service/VideoContentService.java
@@ -1,0 +1,109 @@
+package com.dev.innverview.service;
+
+import com.dev.innverview.domain.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class VideoContentService {
+
+    private final VideoContentRepository contentRepository;
+    private final VideoProjectRepository projectRepository;
+    private final VideoProcessRepository processRepository;
+
+    @Value("${uploads.path}")
+    private String uploadDir;
+
+    public VideoContent uploadFinalVideo(UUID projectId, MultipartFile video) throws IOException {
+        VideoProject project = projectRepository.findById(projectId).orElseThrow();
+        String fileName = UUID.randomUUID() + "_" + video.getOriginalFilename();
+        Path originalDir = Paths.get(uploadDir, "final", "original");
+        Files.createDirectories(originalDir);
+        Path originalPath = originalDir.resolve(fileName);
+        Files.write(originalPath, video.getBytes());
+
+        // HLS directory
+        Path hlsDir = Paths.get(uploadDir, "final", "hls", fileName);
+        Files.createDirectories(hlsDir);
+        Path playlist = hlsDir.resolve("index.m3u8");
+        Files.writeString(playlist, "#EXTM3U\n");
+
+        VideoContent content = VideoContent.builder()
+                .project(project)
+                .originalFileName(fileName)
+                .hlsPath(hlsDir.toString())
+                .build();
+        contentRepository.save(content);
+
+        VideoProcess process = VideoProcess.builder()
+                .content(content)
+                .status(VideoProcess.Status.PROCESSING)
+                .build();
+        processRepository.save(process);
+        processVideoAsync(process, originalPath, playlist);
+        return content;
+    }
+
+    public Path getOriginalPath(VideoContent content) {
+        return Paths.get(uploadDir, "final", "original", content.getOriginalFileName());
+    }
+
+    public Path getHlsPath(VideoContent content) {
+        return Paths.get(content.getHlsPath());
+    }
+
+    public VideoContent findById(UUID id) {
+        return contentRepository.findById(id).orElseThrow();
+    }
+
+    public List<VideoContent> nextContents(UUID afterId, int size) {
+        Pageable page = Pageable.ofSize(size);
+        if (afterId == null) {
+            return contentRepository.findAllByOrderByCreatedAtAsc(page);
+        }
+        VideoContent after = contentRepository.findById(afterId).orElse(null);
+        if (after == null) {
+            return contentRepository.findAllByOrderByCreatedAtAsc(page);
+        }
+        LocalDateTime ts = after.getCreatedAt();
+        return contentRepository.findByCreatedAtAfterOrderByCreatedAtAsc(ts, page);
+    }
+
+    @Async
+    public void processVideoAsync(VideoProcess process, Path source, Path playlist) {
+        try {
+            new ProcessBuilder(
+                    "ffmpeg", "-i", source.toString(),
+                    "-codec", "copy",
+                    "-start_number", "0",
+                    "-hls_time", "10",
+                    "-hls_list_size", "0",
+                    "-f", "hls",
+                    playlist.toString()
+            ).inheritIO().start().waitFor();
+            process.setStatus(VideoProcess.Status.COMPLETED);
+        } catch (Exception e) {
+            process.setStatus(VideoProcess.Status.FAILED);
+            process.setMessage(e.getMessage());
+        } finally {
+            processRepository.save(process);
+        }
+    }
+
+    public VideoProcess status(VideoContent content) {
+        return processRepository.findByContent(content);
+    }
+}

--- a/src/main/java/com/dev/innverview/service/VideoInteractionService.java
+++ b/src/main/java/com/dev/innverview/service/VideoInteractionService.java
@@ -1,0 +1,60 @@
+package com.dev.innverview.service;
+
+import com.dev.innverview.domain.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class VideoInteractionService {
+
+    private final VideoContentRepository contentRepository;
+    private final VideoViewRepository viewRepository;
+    private final VideoLikeRepository likeRepository;
+    private final VideoCommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    public void addView(UUID contentId, String email) {
+        VideoContent content = contentRepository.findById(contentId).orElseThrow();
+        User user = null;
+        if (email != null) {
+            user = userRepository.findByEmail(email).orElse(null);
+        }
+        VideoView view = VideoView.builder()
+                .content(content)
+                .user(user)
+                .build();
+        viewRepository.save(view);
+    }
+
+    public void like(UUID contentId, String email) {
+        VideoContent content = contentRepository.findById(contentId).orElseThrow();
+        User user = userRepository.findByEmail(email).orElseThrow();
+        if (!likeRepository.existsByContentAndUser(content, user)) {
+            VideoLike like = VideoLike.builder()
+                    .content(content)
+                    .user(user)
+                    .build();
+            likeRepository.save(like);
+        }
+    }
+
+    public VideoComment comment(UUID contentId, String email, String text) {
+        VideoContent content = contentRepository.findById(contentId).orElseThrow();
+        User user = userRepository.findByEmail(email).orElseThrow();
+        VideoComment comment = VideoComment.builder()
+                .content(content)
+                .user(user)
+                .text(text)
+                .build();
+        return commentRepository.save(comment);
+    }
+
+    public List<VideoComment> comments(UUID contentId) {
+        VideoContent content = contentRepository.findById(contentId).orElseThrow();
+        return commentRepository.findByContent(content);
+    }
+}

--- a/src/main/java/com/dev/innverview/service/VideoProjectService.java
+++ b/src/main/java/com/dev/innverview/service/VideoProjectService.java
@@ -26,8 +26,9 @@ public class VideoProjectService {
 
     public VideoProject saveProject(User user, String projectName, String editData, MultipartFile video) throws IOException {
         String fileName = UUID.randomUUID() + "_" + video.getOriginalFilename();
-        Path target = Paths.get(uploadDir).resolve(fileName);
-        Files.createDirectories(target.getParent());
+        Path targetDir = Paths.get(uploadDir, "projects");
+        Files.createDirectories(targetDir);
+        Path target = targetDir.resolve(fileName);
         Files.write(target, video.getBytes());
 
         VideoProject project = VideoProject.builder()
@@ -40,7 +41,10 @@ public class VideoProjectService {
     }
 
     public List<VideoProject> list(User user) {
-        return repository.findAll();
+        if (user == null) {
+            return repository.findAll();
+        }
+        return repository.findByUser(user);
     }
 
     public VideoProject findById(UUID id) {

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Sign Up</title>
+</head>
+<body>
+<h1>Register</h1>
+<form method="post" action="/auth/register">
+    <input type="email" name="email" placeholder="Email" required />
+    <input type="password" name="password" placeholder="Password" required />
+    <button type="submit">Sign Up</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/videos.html
+++ b/src/main/resources/templates/videos.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Videos</title>
+</head>
+<body>
+<h1>Short Videos</h1>
+<div id="feed"></div>
+<script>
+fetch('/api/shorts')
+  .then(res => res.json())
+  .then(list => {
+    const feed = document.getElementById('feed');
+    list.forEach(c => {
+      const video = document.createElement('video');
+      video.src = `/api/projects/${c.project.id}/final/hls/${c.id}/index.m3u8`;
+      video.controls = true;
+      feed.appendChild(video);
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new domain `VideoContent` to store finalized videos and HLS info
- implement `VideoContentService` and controller endpoints for uploading final videos and serving HLS/original files
- extend `VideoProjectService` to store project videos under `uploads/projects`
- document new APIs and ERD
- add shorts feed endpoint listing next videos
- provide MySQL schema and docker instructions for running MySQL 8.0

## Testing
- `./gradlew classes` *(fails: Cannot find a Java installation matching toolchain requirements)*
- `./gradlew test` *(fails: Cannot find a Java installation matching toolchain requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68413b2a2290832b9bbfd73e627efc2b