### PR TITLE
Fix MySQL UUID schema mismatch

### DIFF
--- a/src/main/java/com/dev/innverview/domain/InnerView.java
+++ b/src/main/java/com/dev/innverview/domain/InnerView.java
@@ -2,6 +2,7 @@ package com.dev.innverview.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -17,6 +18,8 @@ public class InnerView {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Type(type = "uuid-char")
+    @Column(columnDefinition = "VARCHAR(36)")
     private UUID id;
 
     @Column(nullable = false)

--- a/src/main/java/com/dev/innverview/domain/VideoComment.java
+++ b/src/main/java/com/dev/innverview/domain/VideoComment.java
@@ -2,6 +2,7 @@ package com.dev.innverview.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -17,10 +18,12 @@ public class VideoComment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Type(type = "uuid-char")
+    @Column(columnDefinition = "VARCHAR(36)")
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "content_id")
+    @JoinColumn(name = "content_id", columnDefinition = "VARCHAR(36)")
     private VideoContent content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/dev/innverview/domain/VideoContent.java
+++ b/src/main/java/com/dev/innverview/domain/VideoContent.java
@@ -2,6 +2,7 @@ package com.dev.innverview.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -17,10 +18,12 @@ public class VideoContent {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Type(type = "uuid-char")
+    @Column(columnDefinition = "VARCHAR(36)")
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id")
+    @JoinColumn(name = "project_id", columnDefinition = "VARCHAR(36)")
     private VideoProject project;
 
     @Column(nullable = false)

--- a/src/main/java/com/dev/innverview/domain/VideoLike.java
+++ b/src/main/java/com/dev/innverview/domain/VideoLike.java
@@ -2,6 +2,7 @@ package com.dev.innverview.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -17,10 +18,12 @@ public class VideoLike {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Type(type = "uuid-char")
+    @Column(columnDefinition = "VARCHAR(36)")
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "content_id")
+    @JoinColumn(name = "content_id", columnDefinition = "VARCHAR(36)")
     private VideoContent content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/dev/innverview/domain/VideoProcess.java
+++ b/src/main/java/com/dev/innverview/domain/VideoProcess.java
@@ -2,6 +2,7 @@ package com.dev.innverview.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -24,10 +25,12 @@ public class VideoProcess {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Type(type = "uuid-char")
+    @Column(columnDefinition = "VARCHAR(36)")
     private UUID id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "content_id")
+    @JoinColumn(name = "content_id", columnDefinition = "VARCHAR(36)")
     private VideoContent content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/dev/innverview/domain/VideoProject.java
+++ b/src/main/java/com/dev/innverview/domain/VideoProject.java
@@ -2,6 +2,7 @@ package com.dev.innverview.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -17,6 +18,8 @@ public class VideoProject {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Type(type = "uuid-char")
+    @Column(columnDefinition = "VARCHAR(36)")
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/dev/innverview/domain/VideoView.java
+++ b/src/main/java/com/dev/innverview/domain/VideoView.java
@@ -2,6 +2,7 @@ package com.dev.innverview.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Type;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -17,10 +18,12 @@ public class VideoView {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Type(type = "uuid-char")
+    @Column(columnDefinition = "VARCHAR(36)")
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "content_id")
+    @JoinColumn(name = "content_id", columnDefinition = "VARCHAR(36)")
     private VideoContent content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,8 +45,6 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
-    properties:
-      hibernate.type.preferred_uuid_jdbc_type: CHAR
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,8 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate.type.preferred_uuid_jdbc_type: CHAR
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## Summary
- configure Hibernate to store UUIDs as CHAR to match existing schema

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684147ac1bd0832b80913dda0c212915