### PR TITLE
Fix bean cycle and document JWT secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,6 @@ GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 GOOGLE_REDIRECT_URI=http://localhost:8080/login/oauth2/code/google
 UPLOAD_PATH=uploads
+JWT_SECRET=0123456789abcdef0123456789abcdef
+# JWT_EXPIRATION=3600000
 # 위 값들은 개발용 예시입니다. 실제 서비스에서는 각자의 설정값을 입력하세요.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ docker exec -i innerview-mysql mysql -uroot -ppass innerview < docs/mysql-schema
 ```
 
 ## 주요 환경 변수
-모든 변수는 `.env.example` 파일을 참고하세요. 주요 변수는 다음과 같습니다.
+모든 변수는 `.env.example` 파일을 참고하세요. 자세한 설명은 `docs/ENVIRONMENT.md`를 참고하세요. 주요 변수는 다음과 같습니다.
 - `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET`, `KAKAO_REDIRECT_URI`
 - `SPRINGBOOT_PORT` – 서버 포트
 - 데이터베이스 접속 정보 (`host`, `DB_PORT` 등)
+- `JWT_SECRET` – JWT 서명을 위한 비밀 키
+- `JWT_EXPIRATION` – 토큰 만료 시간(ms, 기본값 3600000)
 
 ## API 개요
 - `POST /api/innerviews` – InnerView 생성

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,18 @@
+# 환경 변수 설정
+
+모든 환경 변수는 프로젝트 루트의 `.env` 파일에서 관리합니다. 예시는 `.env.example`을 참고하세요.
+
+필수 변수
+----------
+- `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET`, `KAKAO_REDIRECT_URI`
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`
+- `SPRINGBOOT_PORT`
+- 데이터베이스 접속 정보(`host`, `DB_PORT`, `database`, `username`, `password`)
+- `JWT_SECRET` – JWT 서명을 위한 비밀 키
+
+선택 변수
+---------
+- `JWT_EXPIRATION` – 토큰 만료 시간(밀리초), 기본값 3600000
+- `UPLOAD_PATH` – 업로드 파일 저장 경로
+
+`.env.example` 파일을 복사하여 `.env`로 사용하고, 위 값들을 환경에 맞게 수정하세요.

--- a/src/main/java/com/dev/innverview/AppConfig.java
+++ b/src/main/java/com/dev/innverview/AppConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
@@ -20,5 +22,11 @@ public class AppConfig {
         restTemplate.setMessageConverters(messageConverters);
 
         return restTemplate;
+    }
+
+    @Bean
+    @org.springframework.context.annotation.Profile("!test")
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/dev/innverview/security/SecurityConfig.java
+++ b/src/main/java/com/dev/innverview/security/SecurityConfig.java
@@ -29,11 +29,6 @@ public class SecurityConfig {
                 .requestMatchers("/images/**", "/js/**", "/css/**", "/static/**", "/favicon.ico", "/error", "/swagger-ui/**");
     }
 
-    @Bean
-    public org.springframework.security.crypto.password.PasswordEncoder passwordEncoder() {
-        return new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder();
-    }
-
     /**
      * Spring Security Filter Chain 설정
      */


### PR DESCRIPTION
## Summary
- move password encoder bean to `AppConfig`
- exclude the bean when running tests
- update `.env.example` with JWT secret info
- document environment variables in `README.md`
- add `docs/ENVIRONMENT.md` for detailed env var description

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68415f8cd7b8832bb514d24ab54e6bad